### PR TITLE
Fix: prevent error disclosure to users

### DIFF
--- a/services/api_gateway/app/logic/endpoints/status.py
+++ b/services/api_gateway/app/logic/endpoints/status.py
@@ -39,6 +39,8 @@ async def get_task_status(task_id: str):
     elif task_result.state == TaskState.failed:
         response.state = TaskState.failed
         response.hint = TaskState.failed.hint
-        response.error = str(task_result.info)
+        # Never expose internal error details (stack traces, exception
+        # messages) to users
+        response.error = "Processing failed. Please try again."
 
     return response

--- a/services/api_gateway/app/logic/endpoints/upload.py
+++ b/services/api_gateway/app/logic/endpoints/upload.py
@@ -189,9 +189,9 @@ def _download_user_speech_from_rutube(task_id: str, video_url: str) -> str:
 
     except subprocess.CalledProcessError as e:
         err_msg = e.stderr.decode() if e.stderr else "Unknown error"
-        logger.error(f"FFmpeg conversion failed: {err_msg}")
+        logger.error("FFmpeg conversion failed: %s", err_msg)
         raise HTTPException(
-            status_code=500, detail=f"Ошибка преобразования видео: {err_msg}"
+            status_code=500, detail="Ошибка преобразования видео"
         )
     except HTTPException:
         raise

--- a/services/api_gateway/app/main.py
+++ b/services/api_gateway/app/main.py
@@ -1,3 +1,4 @@
+import logging
 import re
 
 from charisma_storage import (
@@ -6,11 +7,13 @@ from charisma_storage import (
     get_client,
 )
 from fastapi import FastAPI, HTTPException, Request
-from fastapi.responses import StreamingResponse
+from fastapi.responses import JSONResponse, StreamingResponse
 from starlette.middleware.cors import CORSMiddleware
 
 from app.config import settings
 from app.logic.endpoints import analysis, status, upload
+
+logger = logging.getLogger(__name__)
 
 if settings.mode == "prod" and settings.origin_url == "*":
     raise Exception("You need to specify a specific url for production!")
@@ -21,6 +24,25 @@ app = FastAPI(
     title="Speech Analysis",
     version="1.0.0",
 )
+
+
+@app.exception_handler(Exception)
+async def global_exception_handler(request: Request, exc: Exception):
+    """Catch all unhandled exceptions and return a generic error message.
+
+    Log full details server-side for debugging, but never expose stack traces
+    or internal error details to the client.
+    """
+    logger.error(
+        "Unhandled exception: %s %s",
+        request.method,
+        request.url.path,
+        exc_info=True,
+    )
+    return JSONResponse(
+        status_code=500, content={"detail": "Internal server error"}
+    )
+
 
 app.add_middleware(
     CORSMiddleware,

--- a/services/ml_worker/app/logic/llm_client.py
+++ b/services/ml_worker/app/logic/llm_client.py
@@ -96,7 +96,9 @@ class LLMClient:
                 exc_info=True,
             )
             response = LLMClient._get_empty_speech_analysis_response()
-            response.summary = str(error_msg)
+            response.summary = (
+                "Analysis could not be completed. Please try again."
+            )
             return response
 
     async def get_evaluation_criteria(
@@ -344,8 +346,8 @@ class LLMClient:
         try:
             result = json.loads(cleaned)
             return result
-        except Exception as error_msg:
-            raise error_msg
+        except json.JSONDecodeError:
+            raise RuntimeError("LLM returned invalid JSON response")
 
     @staticmethod
     def _get_empty_speech_analysis_response() -> SpeechReport:

--- a/services/ml_worker/app/logic/ml_engine.py
+++ b/services/ml_worker/app/logic/ml_engine.py
@@ -334,7 +334,10 @@ class MLEngine:
             verify=False,  # noqa: S501
         )
         if response.status_code != 200:
-            raise RuntimeError(f"Sber Auth Error: {response.text}")
+            logger.error(
+                "Sber auth failed: %s %s", response.status_code, response.text
+            )
+            raise RuntimeError("Sber authentication failed")
 
         access_token = response.json()["access_token"]
         auth_header = {"Authorization": f"Bearer {access_token}"}
@@ -355,7 +358,12 @@ class MLEngine:
         )
 
         if r_upload.status_code != 200:
-            raise RuntimeError(f"Sber Upload Error: {r_upload.text}")
+            logger.error(
+                "Sber upload failed: %s %s",
+                r_upload.status_code,
+                r_upload.text,
+            )
+            raise RuntimeError("Sber audio upload failed")
 
         upload_resp = r_upload.json()
 
@@ -392,7 +400,12 @@ class MLEngine:
         )
 
         if r_task.status_code != 200:
-            raise RuntimeError(f"Sber Task Creation Error: {r_task.text}")
+            logger.error(
+                "Sber task creation failed: %s %s",
+                r_task.status_code,
+                r_task.text,
+            )
+            raise RuntimeError("Sber transcription task creation failed")
 
         task_id = r_task.json()["result"]["id"]
         logger.info(f"Sber: Task started, id={task_id}")
@@ -422,7 +435,10 @@ class MLEngine:
                 response_file_id = st_data["response_file_id"]
                 break
             elif st in ["ERROR", "CANCELED"]:
-                raise RuntimeError(f"Sber task failed: {st}")
+                logger.error(
+                    "Sber transcription task failed with status: %s", st
+                )
+                raise RuntimeError("Sber transcription failed")
         else:
             raise TimeoutError("Sber transcription timed out")
 

--- a/services/ml_worker/app/logic/tasks.py
+++ b/services/ml_worker/app/logic/tasks.py
@@ -172,13 +172,12 @@ def process_video_pipeline(  # noqa: C901
         )
 
     except subprocess.CalledProcessError as e:
-        error_msg = f"FFmpeg error: {str(e)}"
-        logger.critical(error_msg)
-        raise RuntimeError(error_msg)
+        logger.critical("FFmpeg error: %s", e.stderr, exc_info=True)
+        raise RuntimeError("Audio extraction failed")
 
     except Exception as e:
-        logger.critical(f"Global pipeline error: {e}")
-        raise RuntimeError(f"Processing failed: {str(e)}")
+        logger.critical("Global pipeline error: %s", e, exc_info=True)
+        raise RuntimeError("Processing failed")
 
     self.update_state(
         state=TaskState.processing.value,
@@ -243,8 +242,10 @@ def process_video_pipeline(  # noqa: C901
             loop.close()
 
         except Exception as e:
-            logger.error(f"Failed to extract evaluation criteria: {e}")
-            raise RuntimeError(f"Criteria extraction failed: {str(e)}")
+            logger.error(
+                "Failed to extract evaluation criteria: %s", e, exc_info=True
+            )
+            raise RuntimeError("Criteria extraction failed")
 
         if criteria_path and os.path.exists(criteria_path):
             os.unlink(criteria_path)
@@ -270,8 +271,8 @@ def process_video_pipeline(  # noqa: C901
         )
         loop.close()
     except Exception as e:
-        logger.error(f"LLM speech analysis failed: {e}")
-        raise RuntimeError(f"Speech analysis failed: {str(e)}")
+        logger.error("LLM speech analysis failed: %s", e, exc_info=True)
+        raise RuntimeError("Speech analysis failed")
 
     self.update_state(
         state=TaskState.processing.value,
@@ -305,8 +306,8 @@ def process_video_pipeline(  # noqa: C901
             f"{evaluation_criteria_total_score}/{evaluation_criteria_max_score}"
         )
     except Exception as e:
-        logger.error(f"Criteria analysis failed: {e}")
-        raise RuntimeError(f"Criteria analysis failed: {str(e)}")
+        logger.error("Criteria analysis failed: %s", e, exc_info=True)
+        raise RuntimeError("Criteria analysis failed")
 
     # TODO: Document and verify these coefficients.
     total_words = len(full_text.split()) if full_text else 1


### PR DESCRIPTION
- Add global exception handler returning generic 500 message
- Sanitize task error responses (never expose stack traces)
- Remove exception details from RuntimeError in Celery tasks
- Replace LLM error messages in user-facing summary field
- Sanitize Sber API error messages (log server-side only)
- Remove FFmpeg stderr from HTTP error responses
- Add exc_info=True to all error logging for server-side debugging