### PR TITLE
feat(k8s): add k8s manifests and CI/CD pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+      - develop
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install ruff
+      - name: Run ruff check
+        run: ruff check --config ./pyproject.toml
+      - name: Run ruff format check
+        run: ruff format --check --config ./pyproject.toml
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install uv
+        run: pip install uv
+      - name: Install dependencies
+        run: uv sync --group dev
+      - name: Run tests
+        run: pytest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,46 +1,109 @@
-name: Deploy to Server
+name: Deploy
 
 on:
-    push:
-        branches:
-            - develop
+  push:
+    branches:
+      - main
 
 jobs:
-    deploy:
-        runs-on: ubuntu-latest
-        steps:
-            - name: Checkout code
-              uses: actions/checkout@v4
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install ruff
+      - name: Run ruff check
+        run: ruff check --config ./pyproject.toml
+      - name: Run ruff format check
+        run: ruff format --check --config ./pyproject.toml
 
-            - name: Setup SSH
-              uses: webfactory/ssh-agent@v0.9.0
-              with:
-                  ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install uv
+        run: pip install uv
+      - name: Install dependencies
+        run: uv sync --group dev
+      - name: Run tests
+        run: pytest
 
-            - name: Add known hosts
-              run: |
-                  echo "Adding SSH host to known hosts..."
-                  ssh-keyscan -p ${{ secrets.SSH_PORT || '22' }} -H ${{ secrets.SSH_HOST }} >> ~/.ssh/known_hosts
-                  echo "SSH host added successfully"
+  build-and-push:
+    runs-on: ubuntu-latest
+    needs: [lint, test]
+    steps:
+      - uses: actions/checkout@v4
 
-            - name: Deploy to server
-              run: |
-                  echo "Starting deployment to server..."
-                  ssh -p ${{ secrets.SSH_PORT || '22' }} ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} << 'EOF'
-                    echo "Changing to project directory..."
-                    cd /home/${{ secrets.SSH_USER }}/charisma-master
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-                    echo "Pulling latest changes from develop branch..."
-                    git pull origin develop
+      - name: Build and push api-gateway
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: services/api_gateway/Dockerfile
+          push: true
+          tags: |
+            ghcr.io/desmitry/charisma-master-api-gateway:${{ github.sha }}
+            ghcr.io/desmitry/charisma-master-api-gateway:latest
 
-                    echo "Stopping & removing existing containers..."
-                    docker compose down
+      - name: Build and push ml-worker
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: services/ml_worker/Dockerfile
+          push: true
+          tags: |
+            ghcr.io/desmitry/charisma-master-ml-worker:${{ github.sha }}
+            ghcr.io/desmitry/charisma-master-ml-worker:latest
 
-                    echo "Running build script..."
-                    ./scripts/build.sh
+      - name: Build and push frontend
+        uses: docker/build-push-action@v5
+        with:
+          context: services/frontend
+          push: true
+          tags: |
+            ghcr.io/desmitry/charisma-master-frontend:${{ github.sha }}
+            ghcr.io/desmitry/charisma-master-frontend:latest
 
-                    echo "Starting containers..."
-                    docker compose up -d
+  deploy:
+    runs-on: ubuntu-latest
+    needs: [build-and-push]
+    steps:
+      - name: Set up kubectl
+        uses: azure/setup-kubectl@v3
 
-                    echo "Deployment completed successfully!"
-                  EOF
+      - name: Configure kubeconfig
+        run: |
+          mkdir -p $HOME/.kube
+          echo "${{ secrets.KUBECONFIG }}" | base64 -d > $HOME/.kube/config
+
+      - name: Deploy api-gateway
+        run: |
+          kubectl set image deployment/api-gateway \
+            api-gateway=ghcr.io/desmitry/charisma-master-api-gateway:${{ github.sha }} \
+            -n charisma
+
+      - name: Deploy ml-worker
+        run: |
+          kubectl set image deployment/ml-worker \
+            ml-worker=ghcr.io/desmitry/charisma-master-ml-worker:${{ github.sha }} \
+            -n charisma
+
+      - name: Deploy frontend
+        run: |
+          kubectl set image deployment/frontend \
+            frontend=ghcr.io/desmitry/charisma-master-frontend:${{ github.sha }} \
+            -n charisma

--- a/k8s/base/api-gateway/deployment.yaml
+++ b/k8s/base/api-gateway/deployment.yaml
@@ -1,0 +1,62 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: api-gateway
+  namespace: charisma
+  labels:
+    app.kubernetes.io/name: api-gateway
+    app.kubernetes.io/part-of: charisma
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: api-gateway
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: api-gateway
+        app.kubernetes.io/part-of: charisma
+    spec:
+      containers:
+        - name: api-gateway
+          image: ghcr.io/desmitry/charisma-master-api-gateway:latest
+          command:
+            - uvicorn
+            - app.main:app
+            - --host
+            - "0.0.0.0"
+            - --port
+            - "8000"
+            - --timeout-keep-alive
+            - "600"
+          ports:
+            - containerPort: 8000
+              protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: charisma-config
+            - secretRef:
+                name: charisma-secret
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            timeoutSeconds: 10
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi

--- a/k8s/base/api-gateway/service.yaml
+++ b/k8s/base/api-gateway/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: api-gateway
+  namespace: charisma
+  labels:
+    app.kubernetes.io/name: api-gateway
+    app.kubernetes.io/part-of: charisma
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: api-gateway
+  ports:
+    - port: 8000
+      targetPort: 8000
+      protocol: TCP
+      name: http

--- a/k8s/base/configmap.yaml
+++ b/k8s/base/configmap.yaml
@@ -1,0 +1,37 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: charisma-config
+  namespace: charisma
+  labels:
+    app.kubernetes.io/part-of: charisma
+data:
+  # Service
+  SERVICE_HOST: "0.0.0.0"
+  SERVICE_PORT: "8000"
+  MODE: "production"
+
+  # Redis / Celery
+  REDIS_URL: "redis://redis:6379/0"
+  CELERY_BROKER_URL: "redis://redis:6379/0"
+  CELERY_RESULT_BACKEND: "redis://redis:6379/1"
+
+  # Database
+  DATABASE_URL: "postgresql://$(POSTGRES_USER):$(POSTGRES_PASSWORD)@postgres:5432/$(POSTGRES_DB)"
+
+  # SeaweedFS
+  SEAWEEDFS_ENDPOINT: "http://seaweedfs:8333"
+
+  # ML / Whisper
+  WHISPER_MODEL_TYPE: "base"
+  WHISPER_DEVICE: "cpu"
+  WHISPER_COMPUTE_TYPE: "int8"
+
+  # LLM model names
+  OPENAI_MODEL_NAME: "gpt-4o"
+  GIGACHAT_MODEL_NAME: "GigaChat"
+
+  # Frontend
+  BACKEND_URL: "http://api-gateway:8000"
+  NODE_ENV: "production"
+  PORT: "3000"

--- a/k8s/base/frontend/deployment.yaml
+++ b/k8s/base/frontend/deployment.yaml
@@ -1,0 +1,56 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend
+  namespace: charisma
+  labels:
+    app.kubernetes.io/name: frontend
+    app.kubernetes.io/part-of: charisma
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: frontend
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: frontend
+        app.kubernetes.io/part-of: charisma
+    spec:
+      containers:
+        - name: frontend
+          image: ghcr.io/desmitry/charisma-master-frontend:latest
+          command:
+            - npm
+            - start
+          ports:
+            - containerPort: 3000
+              protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: charisma-config
+            - secretRef:
+                name: charisma-secret
+          livenessProbe:
+            httpGet:
+              path: /api/health
+              port: 3000
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 10
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /api/health
+              port: 3000
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 300m
+              memory: 512Mi

--- a/k8s/base/frontend/service.yaml
+++ b/k8s/base/frontend/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: frontend
+  namespace: charisma
+  labels:
+    app.kubernetes.io/name: frontend
+    app.kubernetes.io/part-of: charisma
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: frontend
+  ports:
+    - port: 3000
+      targetPort: 3000
+      protocol: TCP
+      name: http

--- a/k8s/base/ingress.yaml
+++ b/k8s/base/ingress.yaml
@@ -1,0 +1,52 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: charisma-ingress
+  namespace: charisma
+  labels:
+    app.kubernetes.io/part-of: charisma
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-body-size: "100m"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "600"
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: charisma.geekiot.tech
+      http:
+        paths:
+          - path: /api
+            pathType: Prefix
+            backend:
+              service:
+                name: api-gateway
+                port:
+                  number: 8000
+          - path: /docs
+            pathType: Prefix
+            backend:
+              service:
+                name: api-gateway
+                port:
+                  number: 8000
+          - path: /media
+            pathType: Prefix
+            backend:
+              service:
+                name: api-gateway
+                port:
+                  number: 8000
+          - path: /health
+            pathType: Prefix
+            backend:
+              service:
+                name: api-gateway
+                port:
+                  number: 8000
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: frontend
+                port:
+                  number: 3000

--- a/k8s/base/kustomization.yaml
+++ b/k8s/base/kustomization.yaml
@@ -1,0 +1,26 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: charisma
+
+resources:
+  - namespace.yaml
+  - configmap.yaml
+  - secret.yaml
+  - postgres/pvc.yaml
+  - postgres/deployment.yaml
+  - postgres/service.yaml
+  - redis/deployment.yaml
+  - redis/service.yaml
+  - seaweedfs/pvc.yaml
+  - seaweedfs/deployment.yaml
+  - seaweedfs/service.yaml
+  - api-gateway/deployment.yaml
+  - api-gateway/service.yaml
+  - ml-worker/deployment.yaml
+  - frontend/deployment.yaml
+  - frontend/service.yaml
+  - ingress.yaml
+
+commonLabels:
+  app.kubernetes.io/managed-by: kustomize

--- a/k8s/base/ml-worker/deployment.yaml
+++ b/k8s/base/ml-worker/deployment.yaml
@@ -1,0 +1,44 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ml-worker
+  namespace: charisma
+  labels:
+    app.kubernetes.io/name: ml-worker
+    app.kubernetes.io/part-of: charisma
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: ml-worker
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: ml-worker
+        app.kubernetes.io/part-of: charisma
+    spec:
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+      containers:
+        - name: ml-worker
+          image: ghcr.io/desmitry/charisma-master-ml-worker:latest
+          command:
+            - celery
+            - -A
+            - app.celery_app
+            - worker
+            - --loglevel=info
+            - --pool=solo
+          envFrom:
+            - configMapRef:
+                name: charisma-config
+            - secretRef:
+                name: charisma-secret
+          resources:
+            requests:
+              cpu: 250m
+              memory: 512Mi
+            limits:
+              cpu: "1"
+              memory: 2Gi

--- a/k8s/base/namespace.yaml
+++ b/k8s/base/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: charisma
+  labels:
+    app.kubernetes.io/part-of: charisma

--- a/k8s/base/postgres/deployment.yaml
+++ b/k8s/base/postgres/deployment.yaml
@@ -1,0 +1,79 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: postgres
+  namespace: charisma
+  labels:
+    app.kubernetes.io/name: postgres
+    app.kubernetes.io/part-of: charisma
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: postgres
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: postgres
+        app.kubernetes.io/part-of: charisma
+    spec:
+      containers:
+        - name: postgres
+          image: postgres:17-alpine
+          ports:
+            - containerPort: 5432
+              protocol: TCP
+          env:
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: charisma-secret
+                  key: POSTGRES_USER
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: charisma-secret
+                  key: POSTGRES_PASSWORD
+            - name: POSTGRES_DB
+              valueFrom:
+                secretKeyRef:
+                  name: charisma-secret
+                  key: POSTGRES_DB
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+          volumeMounts:
+            - name: postgres-data
+              mountPath: /var/lib/postgresql/data
+          livenessProbe:
+            exec:
+              command:
+                - pg_isready
+                - -U
+                - $(POSTGRES_USER)
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 5
+          readinessProbe:
+            exec:
+              command:
+                - pg_isready
+                - -U
+                - $(POSTGRES_USER)
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 5
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+      volumes:
+        - name: postgres-data
+          persistentVolumeClaim:
+            claimName: postgres-pvc

--- a/k8s/base/postgres/pvc.yaml
+++ b/k8s/base/postgres/pvc.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: postgres-pvc
+  namespace: charisma
+  labels:
+    app.kubernetes.io/name: postgres
+    app.kubernetes.io/part-of: charisma
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi

--- a/k8s/base/postgres/service.yaml
+++ b/k8s/base/postgres/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+  namespace: charisma
+  labels:
+    app.kubernetes.io/name: postgres
+    app.kubernetes.io/part-of: charisma
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: postgres
+  ports:
+    - port: 5432
+      targetPort: 5432
+      protocol: TCP
+      name: postgres

--- a/k8s/base/redis/deployment.yaml
+++ b/k8s/base/redis/deployment.yaml
@@ -1,0 +1,54 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis
+  namespace: charisma
+  labels:
+    app.kubernetes.io/name: redis
+    app.kubernetes.io/part-of: charisma
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: redis
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: redis
+        app.kubernetes.io/part-of: charisma
+    spec:
+      containers:
+        - name: redis
+          image: redis:8.6.2
+          command:
+            - redis-server
+          ports:
+            - containerPort: 6379
+              protocol: TCP
+          livenessProbe:
+            exec:
+              command:
+                - redis-cli
+                - ping
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            exec:
+              command:
+                - redis-cli
+                - ping
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 256Mi

--- a/k8s/base/redis/service.yaml
+++ b/k8s/base/redis/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis
+  namespace: charisma
+  labels:
+    app.kubernetes.io/name: redis
+    app.kubernetes.io/part-of: charisma
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: redis
+  ports:
+    - port: 6379
+      targetPort: 6379
+      protocol: TCP
+      name: redis

--- a/k8s/base/seaweedfs/deployment.yaml
+++ b/k8s/base/seaweedfs/deployment.yaml
@@ -1,0 +1,160 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: seaweedfs
+  namespace: charisma
+  labels:
+    app.kubernetes.io/name: seaweedfs
+    app.kubernetes.io/part-of: charisma
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: seaweedfs
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: seaweedfs
+        app.kubernetes.io/part-of: charisma
+    spec:
+      containers:
+        - name: master
+          image: chrislusf/seaweedfs:3.78
+          command:
+            - weed
+            - master
+            - -ip=localhost
+            - -port=9333
+          ports:
+            - containerPort: 9333
+              protocol: TCP
+              name: master
+          volumeMounts:
+            - name: seaweedfs-data
+              mountPath: /data
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 9333
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 5
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 9333
+            initialDelaySeconds: 10
+            periodSeconds: 5
+            timeoutSeconds: 5
+            failureThreshold: 10
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 256Mi
+
+        - name: volume
+          image: chrislusf/seaweedfs:3.78
+          command:
+            - weed
+            - volume
+            - -mserver=localhost:9333
+            - -ip=localhost
+            - -port=8080
+            - -dir=/data
+            - -max=100
+          ports:
+            - containerPort: 8080
+              protocol: TCP
+              name: volume
+          volumeMounts:
+            - name: seaweedfs-data
+              mountPath: /data
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 256Mi
+
+        - name: filer
+          image: chrislusf/seaweedfs:3.78
+          command:
+            - weed
+            - filer
+            - -master=localhost:9333
+            - -ip=localhost
+          ports:
+            - containerPort: 8888
+              protocol: TCP
+              name: filer
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8888
+            initialDelaySeconds: 20
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 5
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8888
+            initialDelaySeconds: 15
+            periodSeconds: 5
+            timeoutSeconds: 5
+            failureThreshold: 10
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 256Mi
+
+        - name: s3
+          image: chrislusf/seaweedfs:3.78
+          command:
+            - weed
+            - s3
+            - -filer=localhost:8888
+            - -ip.bind=0.0.0.0
+            - -port=8333
+          ports:
+            - containerPort: 8333
+              protocol: TCP
+              name: s3
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8333
+            initialDelaySeconds: 25
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 5
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8333
+            initialDelaySeconds: 20
+            periodSeconds: 5
+            timeoutSeconds: 5
+            failureThreshold: 10
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 256Mi
+
+      volumes:
+        - name: seaweedfs-data
+          persistentVolumeClaim:
+            claimName: seaweedfs-pvc

--- a/k8s/base/seaweedfs/pvc.yaml
+++ b/k8s/base/seaweedfs/pvc.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: seaweedfs-pvc
+  namespace: charisma
+  labels:
+    app.kubernetes.io/name: seaweedfs
+    app.kubernetes.io/part-of: charisma
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi

--- a/k8s/base/seaweedfs/service.yaml
+++ b/k8s/base/seaweedfs/service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: seaweedfs
+  namespace: charisma
+  labels:
+    app.kubernetes.io/name: seaweedfs
+    app.kubernetes.io/part-of: charisma
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: seaweedfs
+  ports:
+    - port: 9333
+      targetPort: 9333
+      protocol: TCP
+      name: master
+    - port: 8333
+      targetPort: 8333
+      protocol: TCP
+      name: s3

--- a/k8s/base/secret.yaml
+++ b/k8s/base/secret.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: charisma-secret
+  namespace: charisma
+  labels:
+    app.kubernetes.io/part-of: charisma
+type: Opaque
+stringData:
+  # API keys — replace with real values or use sealed-secrets / external-secrets
+  OPENAI_API_KEY: "CHANGE_ME"
+  GIGACHAT_CREDENTIALS: "CHANGE_ME"
+  SBER_SALUTE_CREDENTIALS: "CHANGE_ME"
+
+  # Origin
+  ORIGIN_URL: "https://charisma.geekiot.tech"
+
+  # Postgres credentials
+  POSTGRES_USER: "charisma"
+  POSTGRES_PASSWORD: "charisma"
+  POSTGRES_DB: "charisma"
+
+  # SeaweedFS credentials
+  SEAWEEDFS_ACCESS_KEY: "CHANGE_ME"
+  SEAWEEDFS_SECRET_KEY: "CHANGE_ME"

--- a/k8s/overlays/prod/kustomization.yaml
+++ b/k8s/overlays/prod/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base
+
+patches:
+  - path: patches/resources.yaml

--- a/k8s/overlays/prod/patches/resources.yaml
+++ b/k8s/overlays/prod/patches/resources.yaml
@@ -1,0 +1,141 @@
+---
+# Production resource limits for api-gateway
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: api-gateway
+  namespace: charisma
+spec:
+  replicas: 2
+  template:
+    spec:
+      containers:
+        - name: api-gateway
+          resources:
+            requests:
+              cpu: 250m
+              memory: 512Mi
+            limits:
+              cpu: "1"
+              memory: 1Gi
+---
+# Production resource limits for ml-worker
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ml-worker
+  namespace: charisma
+spec:
+  replicas: 1
+  template:
+    spec:
+      containers:
+        - name: ml-worker
+          resources:
+            requests:
+              cpu: 500m
+              memory: 1Gi
+            limits:
+              cpu: "2"
+              memory: 4Gi
+---
+# Production resource limits for frontend
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend
+  namespace: charisma
+spec:
+  replicas: 2
+  template:
+    spec:
+      containers:
+        - name: frontend
+          resources:
+            requests:
+              cpu: 200m
+              memory: 256Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+---
+# Production resource limits for postgres
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: postgres
+  namespace: charisma
+spec:
+  template:
+    spec:
+      containers:
+        - name: postgres
+          resources:
+            requests:
+              cpu: 250m
+              memory: 512Mi
+            limits:
+              cpu: "1"
+              memory: 1Gi
+---
+# Production resource limits for redis
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis
+  namespace: charisma
+spec:
+  template:
+    spec:
+      containers:
+        - name: redis
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 300m
+              memory: 512Mi
+---
+# Production resource limits for seaweedfs
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: seaweedfs
+  namespace: charisma
+spec:
+  template:
+    spec:
+      containers:
+        - name: master
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 300m
+              memory: 512Mi
+        - name: volume
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 300m
+              memory: 512Mi
+        - name: filer
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 300m
+              memory: 512Mi
+        - name: s3
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 300m
+              memory: 512Mi


### PR DESCRIPTION
## Summary
- Kubernetes manifests (base + prod overlay) for all services (api-gateway, ml-worker, frontend, postgres, redis, seaweedfs)
- CI/CD pipeline: lint → test → Docker build+push → k8s deploy
- PR CI workflow for lint + test on pull requests