### PR TITLE
Develop (#79)

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -36,6 +36,7 @@ jobs:
           username: ${{ secrets.SSH_USER }}
           key: ${{ secrets.SSH_PRIVATE_KEY }}
           port: ${{ secrets.SSH_PORT || '22' }}
+          debug: true
           script: |
             cd charisma-master
 


### PR DESCRIPTION
* Redesign analysis flow as a step-by-step upload wizard

* Add[Security]: Add GitLeaks pre-commit settings

* Update[Security]: Update gitignore

* Fix: Sync Frontend & Backend
* Пофикшен баг транскрибации с Salute Speech (дублирование куска транскрибированного текста в субтитрах)
* Синхронизирован новый flow анализа выступлений, возможность выбора своего сценария из множества компонентов.

* Redesign analysis flow as a step-by-step upload wizard

* feat(upload): enhance hub ui and add drag-and-drop support

* refactor(upload): overhaul upload hub UI and navigation logic

* feat(ui): add animated Stepper component

* fix(stepper): use ResizeObserver to track dynamic height changes

* feat(analysis): adapt UI to optional video and transcript analysis

Allows the dashboard and activity rings to conditionally render metrics based on whether the user requested video analysis or transcript generation. High-level components now handle missing video paths and empty tempo data gracefully.

* F*ck Apple

* feat(api): add OpenAPI documentation

- Add FastAPI app-level metadata (title, summary, description, contact, license, servers, openapi_tags)
- Introduce 5 tags: Processing, Status, Analysis, Health, Media
- Decorate all endpoints with tags, summary, description, responses
- Preserve all endpoint signatures, parameters, and response_models
- Remove redundant router-level tags on include_router calls (operation-level tags supersede them)

* refactor(ml): split ml_engine.py into modules with facade

- Create ml_engine/ package with audio, video, tempo, scoring, constants, and transcription/ subpackage (sber/local_whisper/openai_whisper)
- Facade class MLEngine preserves 100% backward compat: all public staticmethods/classmethods that tasks.py uses retain original signatures, plus class-level constants (VISUAL_DEVIATION, TARGET_FRAME_WIDTH, MOVEMENT_THRESHOLD, BASE_FILLER_WORDS)
- Use metaclass to expose MLEngine._whisper_local_model as a read-through property backed by the module-level cache in transcription.local_whisper (avoids duplicate state drift between class attr and module global)
- Function bodies copied verbatim from the original 890-line monolith — no cleanups or semantic changes; all noqa/TODO/FIXME comments preserved
- Delete old ml_engine.py
- tasks.py unchanged

* test: add test suite for api_gateway, ml_engine, schemas

- Add pytest, pytest-asyncio, httpx, pytest-cov to dev dependencies
- Configure pytest with testpaths, asyncio_mode=auto, filterwarnings, and packages/ pythonpath
- Add ruff per-file-ignores for tests/** (S101/S105/S106/S108/S311/T201/N802)
- conftest.py provides load_api_gateway/load_ml_worker_module helpers that swap sys.modules so both services' top-level 'app' packages can coexist in one pytest process
- test_schemas.py: 34 tests for charisma_schemas enums and BaseModels
- test_api_gateway/: 16 tests (6 upload, 7 status, 3 analysis) covering develop-style parameter signatures
- test_ml_engine/: 39 tests (30 facade, 9 llm_client) — constants, read-through _whisper_local_model property, transcribe dispatch with negative assertions for wrong branches, backward compat with tasks.py
- Total: 89 tests, passing in ~1.2s

* feat(k8s): add kubernetes manifests with migrator job

Full kustomize stack (base + prod overlay) for the Charisma services declared in docker-compose.yaml.

Base (k8s/base/):
- Namespace charisma, ConfigMap charisma-config, Secret charisma-secrets (placeholder values only), Ingress charisma-ingress (nginx)
- postgres (Deployment + PVC + Service), redis (Deployment + Service)
- seaweedfs (4 Deployments for master/volume/filer/s3 + 4 Services + PVC)
- migrator (batch/v1 Job + RBAC: ServiceAccount charisma-migrator-waiter, Role migrator-job-reader scoped to batch/jobs get/list/watch, RoleBinding)
- api-gateway (Deployment + Service, initContainer wait-for-migrator using bitnami/kubectl with kubectl wait --for=condition=complete --timeout=600s job/migrator)
- ml-worker (Deployment only — Celery worker, no service; same initContainer wait-for-migrator pattern)
- frontend (Deployment + Service)

Overlays:
- k8s/overlays/prod with 3 separate patch files bumping replicas (api-gateway=3, ml-worker=2, frontend=3) and CPU/memory limits

No changes to .github/workflows/ or existing scripts.

* review: address PR #74 feedback

Source changes (per reviewer: 'вернуть теги в include_router'):
- services/api_gateway/app/main.py: restore tags=[...] on three include_router() calls, remove redundant operation-level tags on /process, /status, /wait, /analysis endpoints
- Result: OpenAPI schema still has exactly one tag per operation, no duplicates

Test changes:

tests/test_schemas.py (34 -> 20):
- Remove 14 pure CRUD tests that Pydantic already guarantees via type hints; keep all enum, TaskStage.meta, and business-logic default/optional tests

tests/test_ml_engine/test_ml_engine.py:
- Remove TestWhisperLocalModelProperty (flaky, duplicates TestLoadModel)
- Remove 6 hardcoded score-label tests (incompatible with planned data-driven approach)
- Merge 3 dispatch tests into one parametrized test
- Add TestAnalyzeAudio, TestAnalyzeVideo, TestExtractAudio with happy path + error-propagates cases (facade does not catch)
- Add test_transcribe_unknown_provider_returns_empty_list

tests/test_ml_engine/test_llm_client.py (8 -> 23):
- Fix pytest.raises(Exception) -> pytest.raises(json.JSONDecodeError) with # BUG: documenting traceback loss in _parse_json_response
- Add TestGetEvaluationCriteria (5 tests: json preset, empty json, txt via LLM, unsupported format, empty LLM response)
- Add TestAnalyzeWithEvaluationCriteria (4 tests: happy, empty list, count mismatch, invalid current_value)
- Add TestReadDocumentText (4 tests: txt, docx, empty docx, pdf)
- Add test_call_gigachat_api_error_propagates

tests/test_api_gateway/test_status.py (7 -> 14 methods, 21 invocations):
- Split into TestStatusEndpoint and TestWaitEndpoint classes
- Translate docstrings and inline comments to English
- Add test_unknown_celery_state_returns_as_queued (# BUG: PENDING fallback for RETRY/REVOKED/STARTED/IGNORED), parametrized x5
- Add test_failure_with_exception_object_in_info
- Add test_processing_with_info_string
- Add test_processing_with_partial_info
- Add test_failure_with_no_info (# BUG: str(None) == 'None' leaks)
- Add test_wait_with_pending and test_wait_all_states (parametrized x4)

tests/test_api_gateway/test_upload.py (6 -> 14 methods, 17 invocations):
- Split into TestHappyPath, TestValidation, TestErrorPaths, TestCeleryDispatch, TestEdgeCases
- Add test_ffmpeg_stderr_does_not_leak_to_client — xfail(strict=True) documenting real BUG: stderr embedded in HTTP response detail
- Add test_non_rutube_url_returns_400
- Add test_criteria_preset_not_found_returns_404
- Add test_rutube_video_unavailable_returns_500
- Add test_invalid_criteria_json_returns_422 — xfail(strict=True) documenting missing JSON validation on criteria_file
- Add test_both_video_file_and_url (URL overrides file)
- Add test_presentation_file_is_uploaded
- Add test_all_providers_passed_to_celery (parametrized x4)

tests/test_api_gateway/test_analysis.py (3 -> 4 methods, 7 invocations):
- Merge test_not_found + test_storage_generic_exception into parametrized test_any_storage_error_returns_404 (x4)
- Add test_malformed_schema_returns_422: verifies FastAPI response validation surfaces as ResponseValidationError
- Add test_error_message_not_leaked: security test verifying internal error text is suppressed in client response

Verification:
- uv run pytest tests/ -q -> 115 passed, 2 xfailed in ~4s
- uv run ruff check services/ tests/ packages/ pyproject.toml -> clean
- OpenAPI schema: 6 paths, 5 tags, no duplicates

Not addressed in this commit:
- k8s review deferred per reviewer request
- Source-code bugs flagged via # BUG: comments and xfail(strict=True) markers; will be fixed in follow-up PRs. Strict xfails will XPASS and force test failure as a signal when fixes land.

* style: apply ruff format (CI lint fix)

CI's ruff format --check (which local 'ruff check' doesn't run) flagged 14 files with inline formatting issues — mostly dict/list literals that could be collapsed onto a single line.

No semantic changes. All 115 tests still pass + 2 xfailed unchanged.

* Update demo data S3 store, update frontend handling

* Fix line too long

* Add[CI]: Add building jobs

* Fix[CI]: Added the installation of all packages

* Fix[CI]: Update tests

* Update[CI/CD]: Add deployment with Docker Compose

* Update[CI/CD]: Remove SeaweedFS from k8s manifes

* Hotfix[CI]: Fix uncorrect path

* Hotfix[CI]: Fix uncorrect path

* Fix: Add debug for SSH

---------